### PR TITLE
APIF-318: Detect changed schema min and max.

### DIFF
--- a/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
+++ b/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class OpenApiCompare {
 
-  public static OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+  private static OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
   private static ParseOptions options = new ParseOptions();
 
   static {
@@ -115,4 +115,9 @@ public class OpenApiCompare {
   private static OpenAPI readLocation(String location, List<AuthorizationValue> auths) {
     return openApiParser.read(location, auths, options);
   }
+
+  public static OpenAPIV3Parser getOpenApiParser() {
+    return openApiParser;
+  }
+
 }

--- a/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
+++ b/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
@@ -119,5 +119,5 @@ public class OpenApiCompare {
   public static OpenAPIV3Parser getOpenApiParser() {
     return openApiParser;
   }
-
 }
+

--- a/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
+++ b/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class OpenApiCompare {
 
-  private static OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+  public static OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
   private static ParseOptions options = new ParseOptions();
 
   static {

--- a/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/SchemaDiffResult.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/SchemaDiffResult.java
@@ -54,7 +54,9 @@ public class SchemaDiffResult {
         .setChangeFormat(!Objects.equals(left.getFormat(), right.getFormat()))
         .setReadOnly(new ChangedReadOnly(left.getReadOnly(), right.getReadOnly(), context))
         .setWriteOnly(new ChangedWriteOnly(left.getWriteOnly(), right.getWriteOnly(), context))
-        .setMaxLength(new ChangedMaxLength(left.getMaxLength(), right.getMaxLength(), context));
+        .setMaxLength(new ChangedMaxLength(left.getMaxLength(), right.getMaxLength(), context))
+        .setChangeMinimum(!Objects.equals(left.getMinimum(), right.getMinimum()))
+        .setChangeMaximum(!Objects.equals(left.getMaximum(), right.getMaximum()));
 
     openApiDiff
         .getExtensionsDiff()

--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedSchema.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedSchema.java
@@ -39,6 +39,8 @@ public class ChangedSchema implements ComposedChanged {
   protected ChangedOneOfSchema oneOfSchema;
   protected ChangedSchema addProp;
   private ChangedExtensions extensions;
+  private boolean changeMaximum;
+  private boolean changeMinimum;
 
   public ChangedSchema() {
     increasedProperties = new LinkedHashMap<>();
@@ -73,7 +75,9 @@ public class ChangedSchema implements ComposedChanged {
         && missingProperties.size() == 0
         && changedProperties.values().size() == 0
         && !changeDeprecated
-        && !discriminatorPropertyChanged) {
+        && !discriminatorPropertyChanged
+        && !changeMinimum
+        && !changeMaximum) {
       return DiffResult.NO_CHANGES;
     }
     boolean compatibleForRequest = (oldSchema != null || newSchema == null);
@@ -82,7 +86,9 @@ public class ChangedSchema implements ComposedChanged {
     if ((context.isRequest() && compatibleForRequest
             || context.isResponse() && compatibleForResponse)
         && !changedType
-        && !discriminatorPropertyChanged) {
+        && !discriminatorPropertyChanged
+        && !changeMinimum
+        && !changeMaximum) {
       return DiffResult.COMPATIBLE;
     }
     return DiffResult.INCOMPATIBLE;

--- a/src/test/java/com/qdesrame/openapi/test/BackwardCompatibilityTest.java
+++ b/src/test/java/com/qdesrame/openapi/test/BackwardCompatibilityTest.java
@@ -3,9 +3,15 @@ package com.qdesrame.openapi.test;
 import static com.qdesrame.openapi.test.TestUtils.assertOpenApiBackwardCompatible;
 import static com.qdesrame.openapi.test.TestUtils.assertOpenApiBackwardIncompatible;
 
+import com.qdesrame.openapi.diff.OpenApiCompare;
+import io.swagger.v3.oas.models.OpenAPI;
 import org.junit.jupiter.api.Test;
 
-/** Created by adarsh.sharma on 24/12/17. */
+import java.math.BigDecimal;
+
+/**
+ * Created by adarsh.sharma on 24/12/17.
+ */
 public class BackwardCompatibilityTest {
   private final String OPENAPI_DOC1 = "backwardCompatibility/bc_1.yaml";
   private final String OPENAPI_DOC2 = "backwardCompatibility/bc_2.yaml";
@@ -46,5 +52,71 @@ public class BackwardCompatibilityTest {
   @Test
   public void testApiReadWriteOnlyPropertiesChanged() {
     assertOpenApiBackwardCompatible(OPENAPI_DOC1, OPENAPI_DOC5, true);
+  }
+
+  @Test
+  public void testSchemaMaximumValueAdded() {
+    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMaximumValue(specDiffMaxValue, 123);
+    assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
+  }
+
+  @Test
+  public void testSchemaMaximumValueChanged() {
+    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMaximumValue(spec, 123);
+    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMaximumValue(specDiffMaxValue, 456);
+    assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
+  }
+
+  @Test
+  public void testSchemaMaximumValueRemoved() {
+    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMaximumValue(specDiffMaxValue, 123);
+    assertOpenApiBackwardIncompatible(specDiffMaxValue, spec);
+  }
+
+  @Test
+  public void testSchemaMinimumValueAdded() {
+    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMinimumValue(specDiffMaxValue, 123);
+    assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
+  }
+
+  @Test
+  public void testSchemaMinimumValueRemoved() {
+    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMinimumValue(specDiffMaxValue, 123);
+    assertOpenApiBackwardIncompatible(specDiffMaxValue, spec);
+  }
+
+
+
+  @Test
+  public void testSchemaMinimumValueChanged() {
+    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMinimumValue(spec, 123);
+    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    setMockMinimumValue(specDiffMaxValue, 456);
+    assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
+  }
+
+  private void setMockMaximumValue(OpenAPI spec, int maxValue) {
+    spec.getComponents()
+            .getSchemas()
+            .get("Dog")
+            .setMaximum(new BigDecimal(maxValue));
+  }
+
+  private void setMockMinimumValue(OpenAPI spec, int maxValue) {
+    spec.getComponents()
+            .getSchemas()
+            .get("Dog")
+            .setMinimum(new BigDecimal(maxValue));
   }
 }

--- a/src/test/java/com/qdesrame/openapi/test/BackwardCompatibilityTest.java
+++ b/src/test/java/com/qdesrame/openapi/test/BackwardCompatibilityTest.java
@@ -118,3 +118,4 @@ public class BackwardCompatibilityTest {
             .setMinimum(new BigDecimal(minValue));
   }
 }
+

--- a/src/test/java/com/qdesrame/openapi/test/BackwardCompatibilityTest.java
+++ b/src/test/java/com/qdesrame/openapi/test/BackwardCompatibilityTest.java
@@ -56,52 +56,50 @@ public class BackwardCompatibilityTest {
 
   @Test
   public void testSchemaMaximumValueAdded() {
-    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
-    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI spec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMaximumValue(specDiffMaxValue, 123);
     assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
   }
 
   @Test
   public void testSchemaMaximumValueChanged() {
-    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI spec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMaximumValue(spec, 123);
-    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMaximumValue(specDiffMaxValue, 456);
     assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
   }
 
   @Test
   public void testSchemaMaximumValueRemoved() {
-    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
-    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI spec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMaximumValue(specDiffMaxValue, 123);
     assertOpenApiBackwardIncompatible(specDiffMaxValue, spec);
   }
 
   @Test
   public void testSchemaMinimumValueAdded() {
-    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
-    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI spec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMinimumValue(specDiffMaxValue, 123);
     assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
   }
 
   @Test
   public void testSchemaMinimumValueRemoved() {
-    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
-    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI spec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMinimumValue(specDiffMaxValue, 123);
     assertOpenApiBackwardIncompatible(specDiffMaxValue, spec);
   }
-
-
-
+  
   @Test
   public void testSchemaMinimumValueChanged() {
-    OpenAPI spec = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI spec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMinimumValue(spec, 123);
-    OpenAPI specDiffMaxValue = OpenApiCompare.openApiParser.read(OPENAPI_DOC5);
+    OpenAPI specDiffMaxValue = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC5);
     setMockMinimumValue(specDiffMaxValue, 456);
     assertOpenApiBackwardIncompatible(spec, specDiffMaxValue);
   }
@@ -113,10 +111,10 @@ public class BackwardCompatibilityTest {
             .setMaximum(new BigDecimal(maxValue));
   }
 
-  private void setMockMinimumValue(OpenAPI spec, int maxValue) {
+  private void setMockMinimumValue(OpenAPI spec, int minValue) {
     spec.getComponents()
             .getSchemas()
             .get("Dog")
-            .setMinimum(new BigDecimal(maxValue));
+            .setMinimum(new BigDecimal(minValue));
   }
 }

--- a/src/test/java/com/qdesrame/openapi/test/TestUtils.java
+++ b/src/test/java/com/qdesrame/openapi/test/TestUtils.java
@@ -5,6 +5,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import com.qdesrame.openapi.diff.OpenApiCompare;
 import com.qdesrame.openapi.diff.model.ChangedOpenApi;
+import io.swagger.v3.oas.models.OpenAPI;
 import org.slf4j.Logger;
 
 public class TestUtils {
@@ -35,6 +36,12 @@ public class TestUtils {
 
   public static void assertOpenApiBackwardIncompatible(String oldSpec, String newSpec) {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(oldSpec, newSpec);
+    LOG.info("Result: {}", changedOpenApi.isChanged().getValue());
+    assertThat(changedOpenApi.isIncompatible()).isTrue();
+  }
+
+  public static void assertOpenApiBackwardIncompatible(OpenAPI oldSpec, OpenAPI newSpec) {
+    ChangedOpenApi changedOpenApi = OpenApiCompare.fromSpecifications(oldSpec, newSpec);
     LOG.info("Result: {}", changedOpenApi.isChanged().getValue());
     assertThat(changedOpenApi.isIncompatible()).isTrue();
   }


### PR DESCRIPTION
See title. OAD doesn't detect changes if the schema isn't actually used anywhere (e.g: `Pet` schema in `bc_5.yaml`). This doesn't address that (if that actually needs to be addressed). This change just detects changes to min/max in properties and classifies them as breaking.