### PR TITLE
Add ability to detect changes in oneOf schemas without discriminators.

### DIFF
--- a/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
+++ b/src/main/java/com/qdesrame/openapi/diff/OpenApiCompare.java
@@ -115,4 +115,8 @@ public class OpenApiCompare {
   private static OpenAPI readLocation(String location, List<AuthorizationValue> auths) {
     return openApiParser.read(location, auths, options);
   }
+
+  public static OpenAPIV3Parser getOpenApiParser() {
+    return openApiParser;
+  }
 }

--- a/src/main/java/com/qdesrame/openapi/diff/compare/SchemaDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/SchemaDiff.java
@@ -77,7 +77,7 @@ public class SchemaDiff extends ReferenceDiffCache<Schema, ChangedSchema> {
     }
   }
 
-  protected static Schema resolveComposedSchema(Components components, Schema schema) {
+  public static Schema resolveComposedSchema(Components components, Schema schema) {
     if (schema instanceof ComposedSchema) {
       ComposedSchema composedSchema = (ComposedSchema) schema;
       List<Schema> allOfSchemaList = composedSchema.getAllOf();

--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedSchema.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedSchema.java
@@ -76,6 +76,7 @@ public class ChangedSchema implements ComposedChanged {
         && !discriminatorPropertyChanged) {
       return DiffResult.NO_CHANGES;
     }
+    // TODO: Detect added required properties and report broken compatibility.
     boolean compatibleForRequest = (oldSchema != null || newSchema == null);
     boolean compatibleForResponse =
         missingProperties.isEmpty() && (oldSchema == null || newSchema != null);

--- a/src/test/java/com/qdesrame/openapi/test/OneOfDiffTest.java
+++ b/src/test/java/com/qdesrame/openapi/test/OneOfDiffTest.java
@@ -4,9 +4,20 @@ import static com.qdesrame.openapi.test.TestUtils.assertOpenApiAreEquals;
 import static com.qdesrame.openapi.test.TestUtils.assertOpenApiBackwardIncompatible;
 import static com.qdesrame.openapi.test.TestUtils.assertOpenApiChangedEndpoints;
 
+import com.qdesrame.openapi.diff.OpenApiCompare;
+import com.qdesrame.openapi.diff.model.ChangedOpenApi;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
-/** Created by adarsh.sharma on 19/12/17. */
+import java.util.Map;
+
+/**
+ * Created by adarsh.sharma on 19/12/17.
+ */
 public class OneOfDiffTest {
 
   private final String OPENAPI_DOC1 = "oneOf_diff_1.yaml";
@@ -41,5 +52,38 @@ public class OneOfDiffTest {
   public void testOneOfDiscrimitatorChanged() {
     // The oneOf 'discriminator' changed: 'realtype' -> 'othertype':
     assertOpenApiBackwardIncompatible(OPENAPI_DOC6, OPENAPI_DOC7);
+  }
+
+  @Test
+  public void testOneOfWithNoDiscriminatorChanged() {
+    OpenAPI oldSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
+    OpenAPI newSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
+    oldSpec.getComponents().getSchemas().get("Pet").setDiscriminator(null);
+    newSpec.getComponents().getSchemas().get("Pet").setDiscriminator(null);
+    Schema schema = newSpec.getComponents().getSchemas().get("Dog");
+    schema.getProperties().remove("bark");
+    assertOpenApiBackwardIncompatible(oldSpec, newSpec);
+  }
+
+  @Test
+  public void testOldOneOfWithDiscriminatorWithNoPropertyName() {
+    OpenAPI oldSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
+    OpenAPI newSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
+    Discriminator disc = newSpec.getComponents().getSchemas().get("Pet").getDiscriminator();
+    disc.setPropertyName(null);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      assertOpenApiBackwardIncompatible(oldSpec, newSpec);
+    });
+  }
+
+  @Test
+  public void testNewOneOfWithDiscriminatorWithNoPropertyName() {
+    OpenAPI oldSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
+    OpenAPI newSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
+    Discriminator disc = oldSpec.getComponents().getSchemas().get("Pet").getDiscriminator();
+    disc.setPropertyName(null);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      assertOpenApiBackwardIncompatible(oldSpec, newSpec);
+    });
   }
 }

--- a/src/test/java/com/qdesrame/openapi/test/OneOfDiffTest.java
+++ b/src/test/java/com/qdesrame/openapi/test/OneOfDiffTest.java
@@ -69,7 +69,7 @@ public class OneOfDiffTest {
   public void testOldOneOfWithDiscriminatorWithNoPropertyName() {
     OpenAPI oldSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
     OpenAPI newSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
-    Discriminator disc = newSpec.getComponents().getSchemas().get("Pet").getDiscriminator();
+    Discriminator disc = oldSpec.getComponents().getSchemas().get("Pet").getDiscriminator();
     disc.setPropertyName(null);
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
       assertOpenApiBackwardIncompatible(oldSpec, newSpec);
@@ -80,7 +80,7 @@ public class OneOfDiffTest {
   public void testNewOneOfWithDiscriminatorWithNoPropertyName() {
     OpenAPI oldSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
     OpenAPI newSpec = OpenApiCompare.getOpenApiParser().read(OPENAPI_DOC2);
-    Discriminator disc = oldSpec.getComponents().getSchemas().get("Pet").getDiscriminator();
+    Discriminator disc = newSpec.getComponents().getSchemas().get("Pet").getDiscriminator();
     disc.setPropertyName(null);
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
       assertOpenApiBackwardIncompatible(oldSpec, newSpec);

--- a/src/test/java/com/qdesrame/openapi/test/TestUtils.java
+++ b/src/test/java/com/qdesrame/openapi/test/TestUtils.java
@@ -5,6 +5,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import com.qdesrame.openapi.diff.OpenApiCompare;
 import com.qdesrame.openapi.diff.model.ChangedOpenApi;
+import io.swagger.v3.oas.models.OpenAPI;
 import org.slf4j.Logger;
 
 public class TestUtils {
@@ -35,6 +36,12 @@ public class TestUtils {
 
   public static void assertOpenApiBackwardIncompatible(String oldSpec, String newSpec) {
     ChangedOpenApi changedOpenApi = OpenApiCompare.fromLocations(oldSpec, newSpec);
+    LOG.info("Result: {}", changedOpenApi.isChanged().getValue());
+    assertThat(changedOpenApi.isIncompatible()).isTrue();
+  }
+
+  public static void assertOpenApiBackwardIncompatible(OpenAPI oldSpec, OpenAPI newSpec) {
+    ChangedOpenApi changedOpenApi = OpenApiCompare.fromSpecifications(oldSpec, newSpec);
     LOG.info("Result: {}", changedOpenApi.isChanged().getValue());
     assertThat(changedOpenApi.isIncompatible()).isTrue();
   }


### PR DESCRIPTION
See title. Implemented this in an ordered way, but made a TODO to make it unordered in the future if needed.

TODO: Add tests.